### PR TITLE
Updated minecraft versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     `maven-publish`
 }
 
-val baseVersion = "0.0.1"
+val baseVersion = "0.0.2"
 val commitHash = System.getenv("COMMIT_HASH")
 val snapshotversion = "${baseVersion}-dev.$commitHash"
 

--- a/connection-bungeecord/build.gradle.kts
+++ b/connection-bungeecord/build.gradle.kts
@@ -27,7 +27,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("bungeecord")
     changelog.set("https://docs.simplecloud.app/changelog")

--- a/connection-velocity/build.gradle.kts
+++ b/connection-velocity/build.gradle.kts
@@ -27,7 +27,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("velocity")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported versions for the `modrinth` configuration in two build files, ensuring compatibility with newer versions of the software.

### Version updates:

* [`connection-bungeecord/build.gradle.kts`](diffhunk://#diff-c47ae8736612dcd670d3c159625d1d36b98ba034fb5971bac4f743040be80cc3L30-R34): Added support for versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` in the `modrinth` configuration.
* [`connection-velocity/build.gradle.kts`](diffhunk://#diff-39bbda3341d29236ad8c943617e242177d3a85b178091df0124654f58a1c3aecL30-R34): Added support for versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` in the `modrinth` configuration.