### PR TITLE
feat: subdomain support

### DIFF
--- a/connection-bungeecord/src/main/kotlin/app/simplecloud/plugin/connection/bungeecord/listener/ServerConnectListener.kt
+++ b/connection-bungeecord/src/main/kotlin/app/simplecloud/plugin/connection/bungeecord/listener/ServerConnectListener.kt
@@ -19,22 +19,20 @@ class ServerConnectListener(
         val config = plugin.connectionPlugin.connectionConfig.get()
         val messages = plugin.connectionPlugin.messageConfig.get()
 
-        if (config.subdomain.enabled) {
-            val virtualHost = event.player.pendingConnection.virtualHost?.hostName
-            if (virtualHost != null) {
-                val route = config.subdomain.routes.find { it.subdomain == virtualHost }
-                if (route != null) {
-                    val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
-                    if (connection != null) {
-                        val serverNames = plugin.proxy.servers.keys.toList()
-                        val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
-                        val targetServer = matchingNames
-                            .mapNotNull { plugin.proxy.servers[it] }
-                            .minByOrNull { it.players.size }
-                        if (targetServer != null) {
-                            event.target = targetServer
-                            return
-                        }
+        val virtualHost = event.player.pendingConnection.virtualHost?.hostName
+        if (virtualHost != null) {
+            val route = config.address.routes.find { it.subdomain == virtualHost }
+            if (route != null) {
+                val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
+                if (connection != null) {
+                    val serverNames = plugin.proxy.servers.keys.toList()
+                    val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
+                    val targetServer = matchingNames
+                        .mapNotNull { plugin.proxy.servers[it] }
+                        .minByOrNull { it.players.size }
+                    if (targetServer != null) {
+                        event.target = targetServer
+                        return
                     }
                 }
             }

--- a/connection-bungeecord/src/main/kotlin/app/simplecloud/plugin/connection/bungeecord/listener/ServerConnectListener.kt
+++ b/connection-bungeecord/src/main/kotlin/app/simplecloud/plugin/connection/bungeecord/listener/ServerConnectListener.kt
@@ -19,6 +19,27 @@ class ServerConnectListener(
         val config = plugin.connectionPlugin.connectionConfig.get()
         val messages = plugin.connectionPlugin.messageConfig.get()
 
+        if (config.subdomain.enabled) {
+            val virtualHost = event.player.pendingConnection.virtualHost?.hostName
+            if (virtualHost != null) {
+                val route = config.subdomain.routes.find { it.subdomain == virtualHost }
+                if (route != null) {
+                    val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
+                    if (connection != null) {
+                        val serverNames = plugin.proxy.servers.keys.toList()
+                        val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
+                        val targetServer = matchingNames
+                            .mapNotNull { plugin.proxy.servers[it] }
+                            .minByOrNull { it.players.size }
+                        if (targetServer != null) {
+                            event.target = targetServer
+                            return
+                        }
+                    }
+                }
+            }
+        }
+
         if (!config.networkJoinTargets.enabled) return
 
         val serverNames = plugin.proxy.servers.keys.toList()

--- a/connection-shared/src/main/kotlin/app/simplecloud/plugin/connection/shared/config/ConnectionConfig.kt
+++ b/connection-shared/src/main/kotlin/app/simplecloud/plugin/connection/shared/config/ConnectionConfig.kt
@@ -10,6 +10,7 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable
 data class ConnectionConfig(
     val version: Char = ConfigVersion.VERSION,
     val registration: RegistrationConfig = RegistrationConfig(),
+    val subdomain: SubdomainConfig = SubdomainConfig(),
     val connections: List<ConnectionEntry> = DefaultConfigs.CONNECTIONS,
     val networkJoinTargets: NetworkJoinTargetsConfig = DefaultConfigs.NETWORK_JOIN_TARGETS,
     val fallback: FallbackConfig = DefaultConfigs.FALLBACK,
@@ -29,6 +30,18 @@ data class RegistrationServer(
     val name: String = "",
     val address: String = "",
     val port: Long = 0L
+)
+
+@ConfigSerializable
+data class SubdomainConfig(
+    val enabled: Boolean = true,
+    val mappings: List<SubdomainMapping> = listOf()
+)
+
+@ConfigSerializable
+data class SubdomainMapping(
+    val subdomain: String = "",
+    val targetConnection: String = ""
 )
 
 @ConfigSerializable

--- a/connection-shared/src/main/kotlin/app/simplecloud/plugin/connection/shared/config/ConnectionConfig.kt
+++ b/connection-shared/src/main/kotlin/app/simplecloud/plugin/connection/shared/config/ConnectionConfig.kt
@@ -10,7 +10,7 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable
 data class ConnectionConfig(
     val version: Char = ConfigVersion.VERSION,
     val registration: RegistrationConfig = RegistrationConfig(),
-    val subdomain: SubdomainConfig = SubdomainConfig(),
+    val address: AddressConfig = AddressConfig(),
     val connections: List<ConnectionEntry> = DefaultConfigs.CONNECTIONS,
     val networkJoinTargets: NetworkJoinTargetsConfig = DefaultConfigs.NETWORK_JOIN_TARGETS,
     val fallback: FallbackConfig = DefaultConfigs.FALLBACK,
@@ -33,8 +33,7 @@ data class RegistrationServer(
 )
 
 @ConfigSerializable
-data class SubdomainConfig(
-    val enabled: Boolean = true,
+data class AddressConfig(
     val routes: List<SubdomainRoute> = listOf()
 )
 

--- a/connection-shared/src/main/kotlin/app/simplecloud/plugin/connection/shared/config/ConnectionConfig.kt
+++ b/connection-shared/src/main/kotlin/app/simplecloud/plugin/connection/shared/config/ConnectionConfig.kt
@@ -35,11 +35,11 @@ data class RegistrationServer(
 @ConfigSerializable
 data class SubdomainConfig(
     val enabled: Boolean = true,
-    val mappings: List<SubdomainMapping> = listOf()
+    val routes: List<SubdomainRoute> = listOf()
 )
 
 @ConfigSerializable
-data class SubdomainMapping(
+data class SubdomainRoute(
     val subdomain: String = "",
     val targetConnection: String = ""
 )

--- a/connection-velocity/src/main/kotlin/app/simplecloud/plugin/connection/velocity/listener/PlayerChooseInitialServerListener.kt
+++ b/connection-velocity/src/main/kotlin/app/simplecloud/plugin/connection/velocity/listener/PlayerChooseInitialServerListener.kt
@@ -16,22 +16,20 @@ class PlayerChooseInitialServerListener(
         val config = plugin.connectionPlugin.connectionConfig.get()
         val messages = plugin.connectionPlugin.messageConfig.get()
 
-        if (config.subdomain.enabled) {
-            val virtualHost = event.player.virtualHost.map { it.hostName }.orElse(null)
-            if (virtualHost != null) {
-                val mapping = config.subdomain.routes.find { it.subdomain == virtualHost }
-                if (mapping != null) {
-                    val connection = ConnectionResolver.findConnection(mapping.targetConnection, config.connections)
-                    if (connection != null) {
-                        val serverNames = proxy.allServers.map { it.serverInfo.name }
-                        val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
-                        val server = matchingNames
-                            .mapNotNull { proxy.getServer(it).orElse(null) }
-                            .minByOrNull { it.playersConnected.size }
-                        if (server != null) {
-                            event.setInitialServer(server)
-                            return
-                        }
+        val virtualHost = event.player.virtualHost.map { it.hostName }.orElse(null)
+        if (virtualHost != null) {
+            val route = config.address.routes.find { it.subdomain == virtualHost }
+            if (route != null) {
+                val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
+                if (connection != null) {
+                    val serverNames = proxy.allServers.map { it.serverInfo.name }
+                    val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
+                    val server = matchingNames
+                        .mapNotNull { proxy.getServer(it).orElse(null) }
+                        .minByOrNull { it.playersConnected.size }
+                    if (server != null) {
+                        event.setInitialServer(server)
+                        return
                     }
                 }
             }

--- a/connection-velocity/src/main/kotlin/app/simplecloud/plugin/connection/velocity/listener/PlayerChooseInitialServerListener.kt
+++ b/connection-velocity/src/main/kotlin/app/simplecloud/plugin/connection/velocity/listener/PlayerChooseInitialServerListener.kt
@@ -19,7 +19,7 @@ class PlayerChooseInitialServerListener(
         if (config.subdomain.enabled) {
             val virtualHost = event.player.virtualHost.map { it.hostName }.orElse(null)
             if (virtualHost != null) {
-                val mapping = config.subdomain.mappings.find { it.subdomain == virtualHost }
+                val mapping = config.subdomain.routes.find { it.subdomain == virtualHost }
                 if (mapping != null) {
                     val connection = ConnectionResolver.findConnection(mapping.targetConnection, config.connections)
                     if (connection != null) {

--- a/connection-velocity/src/main/kotlin/app/simplecloud/plugin/connection/velocity/listener/PlayerChooseInitialServerListener.kt
+++ b/connection-velocity/src/main/kotlin/app/simplecloud/plugin/connection/velocity/listener/PlayerChooseInitialServerListener.kt
@@ -16,6 +16,27 @@ class PlayerChooseInitialServerListener(
         val config = plugin.connectionPlugin.connectionConfig.get()
         val messages = plugin.connectionPlugin.messageConfig.get()
 
+        if (config.subdomain.enabled) {
+            val virtualHost = event.player.virtualHost.map { it.hostName }.orElse(null)
+            if (virtualHost != null) {
+                val mapping = config.subdomain.mappings.find { it.subdomain == virtualHost }
+                if (mapping != null) {
+                    val connection = ConnectionResolver.findConnection(mapping.targetConnection, config.connections)
+                    if (connection != null) {
+                        val serverNames = proxy.allServers.map { it.serverInfo.name }
+                        val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
+                        val server = matchingNames
+                            .mapNotNull { proxy.getServer(it).orElse(null) }
+                            .minByOrNull { it.playersConnected.size }
+                        if (server != null) {
+                            event.setInitialServer(server)
+                            return
+                        }
+                    }
+                }
+            }
+        }
+
         if (!config.networkJoinTargets.enabled) return
 
         val serverNames = proxy.allServers.map { it.serverInfo.name }

--- a/connection-waterdog/src/main/kotlin/app/simplecloud/plugin/connection/waterdog/handler/WaterdogJoinHandler.kt
+++ b/connection-waterdog/src/main/kotlin/app/simplecloud/plugin/connection/waterdog/handler/WaterdogJoinHandler.kt
@@ -13,19 +13,17 @@ class WaterdogJoinHandler(
     override fun determineServer(player: ProxiedPlayer): ServerInfo? {
         val config = plugin.connectionPlugin.connectionConfig.get()
 
-        if (config.subdomain.enabled) {
-            val virtualHost = player.loginData.joinHostname
-            val route = config.subdomain.routes.find { it.subdomain == virtualHost }
-            if (route != null) {
-                val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
-                if (connection != null) {
-                    val serverNames = plugin.proxy.servers.map { it.serverName }
-                    val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
-                    val serverInfo = matchingNames
-                        .mapNotNull { name -> plugin.proxy.getServerInfo(name) }
-                        .minByOrNull { it.players.size }
-                    if (serverInfo != null) return serverInfo
-                }
+        val virtualHost = player.loginData.joinHostname
+        val route = config.address.routes.find { it.subdomain == virtualHost }
+        if (route != null) {
+            val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
+            if (connection != null) {
+                val serverNames = plugin.proxy.servers.map { it.serverName }
+                val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
+                val serverInfo = matchingNames
+                    .mapNotNull { name -> plugin.proxy.getServerInfo(name) }
+                    .minByOrNull { it.players.size }
+                if (serverInfo != null) return serverInfo
             }
         }
 

--- a/connection-waterdog/src/main/kotlin/app/simplecloud/plugin/connection/waterdog/handler/WaterdogJoinHandler.kt
+++ b/connection-waterdog/src/main/kotlin/app/simplecloud/plugin/connection/waterdog/handler/WaterdogJoinHandler.kt
@@ -13,6 +13,22 @@ class WaterdogJoinHandler(
     override fun determineServer(player: ProxiedPlayer): ServerInfo? {
         val config = plugin.connectionPlugin.connectionConfig.get()
 
+        if (config.subdomain.enabled) {
+            val virtualHost = player.loginData.joinHostname
+            val route = config.subdomain.routes.find { it.subdomain == virtualHost }
+            if (route != null) {
+                val connection = ConnectionResolver.findConnection(route.targetConnection, config.connections)
+                if (connection != null) {
+                    val serverNames = plugin.proxy.servers.map { it.serverName }
+                    val matchingNames = ConnectionResolver.findMatchingServerNames(connection, serverNames)
+                    val serverInfo = matchingNames
+                        .mapNotNull { name -> plugin.proxy.getServerInfo(name) }
+                        .minByOrNull { it.players.size }
+                    if (serverInfo != null) return serverInfo
+                }
+            }
+        }
+
         if (!config.networkJoinTargets.enabled) return null
 
         val serverNames = plugin.proxy.servers.map { it.serverName }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 kotlin = "2.2.20"
 kotlin-coroutines = "1.10.2"
 
-shadow = "9.3.2"
-minotaur = "2.8.10"
+shadow = "9.4.1"
+minotaur = "2.9.0"
 
-simplecloud-api = "0.1.0-platform.20-dev.1771710355025-becd984"
+simplecloud-api = "0.1.0-platform.22-dev.1774376168759-1e20f57"
 simplecloud-plugin-api = "0.0.1-platform.1766000824440-e57ed95"
 
 velocity = "3.5.0-SNAPSHOT"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
 - Adds `subdomain` config section to map subdomains to connections                                                                                                                   

## Example Config
```yml
subdomain:
    enabled: true
    routes:
      - subdomain: "build.example.com"
        target-connection: "build"
```